### PR TITLE
Resolves S842: AWS operations on native aws plugin that expect a JSON

### DIFF
--- a/aws/awsutil/blinkutil.go
+++ b/aws/awsutil/blinkutil.go
@@ -35,6 +35,13 @@ var (
 )
 
 func resolveParameter(parent string, parameter string, shape reflect.Value) interface{} {
+	// AssumeRolePolicyDocument comes as a string. we MUST NOT modify it
+	// This may apply to other objects that AWS expects to receive as a JSON-string
+	// reference: https://docs.aws.amazon.com/sdk-for-go/api/service/iam/#CreateRoleInput
+	if strings.Contains(parameter, "Statement") {
+		return parameter
+	}
+
 	if strings.Contains(parameter, " ") {
 		return resolveListMapParameter(parent, strings.Split(parameter, " "), shape)
 	}


### PR DESCRIPTION
string don't work at all

This change may seem odd, but as mentioned in the comment, AWS IAM policies expect a JSON-string input, and until now, we tried to process them, but we should not. we should pass them as is.

A screenshot indicating the bugfix was added to the original bug ticket.

Tested a couple more operations to make sure nothing broke, all were successful.