### PR TITLE
Reshefs/s1065/support aws assume role

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 )
 

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -2010,9 +2010,8 @@ func detectConnectionType(awsCredentials map[string]string) (credsType, key, val
 	if awsCredentials[awsAccessKeyId] == "" || awsCredentials[awsSecretAccessKey] == "" {
 		if awsCredentials[roleArn] == "" {
 			return "", "", ""
-		} else {
-			return "roleBased", awsCredentials[roleArn], awsCredentials[externalID]
 		}
+		return "roleBased", awsCredentials[roleArn], awsCredentials[externalID]
 	}
 	return "userBased", awsCredentials[awsAccessKeyId], awsCredentials[awsSecretAccessKey]
 }

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -2006,6 +2006,7 @@ func createAWSSessionByContext(region string, context *plugin.ActionContext, tim
 // role arn can be supplied alone if it's irsa
 // role arn and external id have to be supplied together for traditional assume role
 func detectConnectionType(awsCredentials map[string]string) (credsType, key, value string) {
+	log.Debug(awsCredentials[roleArn], awsCredentials[externalID], awsCredentials[awsAccessKeyId], awsCredentials[awsSecretAccessKey])
 	if awsCredentials[awsAccessKeyId] == "" || awsCredentials[awsSecretAccessKey] == "" {
 		if awsCredentials[roleArn] == "" {
 			return "", "", ""
@@ -2095,7 +2096,7 @@ func createAWSSessionByCredentials(region string, awsCredentials map[string]inte
 	case "userBased":
 		access, secret, sessionToken = k, v, ""
 	default:
-		return nil, fmt.Errorf("invalid credentials: make sure access+secret key are supplied OR role_arn and/orexternal_id")
+		return nil, fmt.Errorf("invalid credentials: make sure access+secret key are supplied OR role_arn and/or external_id")
 	}
 
 	// setting the credentials we just obtained

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -2057,6 +2057,9 @@ func assumeRoleWithWebIdentity(svc *sts.STS, role, sessionName string) (string, 
 		RoleSessionName:  aws.String(sessionName),
 		WebIdentityToken: aws.String(string(data)),
 	})
+	if err != nil {
+		return "", "", "", err
+	}
 	return *result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken, err
 }
 
@@ -2067,6 +2070,9 @@ func assumeRoleWithTrustedIdentity(svc *sts.STS, role, externalID, sessionName s
 		RoleSessionName: &sessionName,
 		ExternalId:      &externalID,
 	})
+	if err != nil {
+		return "", "", "", err
+	}
 	return *result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken, err
 }
 

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -2038,6 +2038,11 @@ func assumeRole(role, externalID, region string) (access, secret, sessionToken s
 
 	// irsa does not work with externalID, only the "traditional" assume role does
 	if externalID == "" {
+		tokenFile, ok := os.LookupEnv("AWS_WEB_IDENTITY_TOKEN_FILE")
+		if !ok {
+			return access, secret, sessionToken, fmt.Errorf("token file for irsa not found. make sure pod is configured correctly and that your service account is created and properly annotated")
+		}
+
 		log.Debug("assuming role with web identity")
 		data, err := ioutil.ReadFile(tokenFile)
 		if err != nil {

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -1898,10 +1898,6 @@ func (p *AWSPlugin) TestCredentials(credentialsMap map[string]connections.Connec
 			}, err
 		}
 
-		// check whether both role_arn and extenral_id are set.
-		// if they are, do assume role.
-		//
-
 		serviceName := "sts"
 		serviceRegions := awsutil.GetServiceRegions(serviceName)
 
@@ -2031,6 +2027,8 @@ func convertInterfaceMapToStringMap(m map[string]interface{}) map[string]string 
 }
 
 func assumeRole(role, externalID, region string) (creds *credentials.Credentials, err error) {
+	log.Debug("attempting to assume role")
+	log.Debugf("%s, %s, %s", role, externalID, region)
 	sess, _ := session.NewSession(&aws.Config{
 		Region: aws.String(region),
 	})
@@ -2052,6 +2050,8 @@ func assumeRole(role, externalID, region string) (creds *credentials.Credentials
 
 
 func createAWSSessionByCredentials(region string, awsCredentials map[string]interface{}, timeout int32) (*session.Session, error) {
+	log.Debug("inside createAWSSessionByCredentials")
+	log.Debugf("%+v\n", awsCredentials)
 	var creds *credentials.Credentials
 
 	m := convertInterfaceMapToStringMap(awsCredentials)
@@ -2072,6 +2072,7 @@ func createAWSSessionByCredentials(region string, awsCredentials map[string]inte
 		return nil, fmt.Errorf("invalid credentials: make sure access+secret key are supplied OR role_arn+external_id")
 	}
 
+	log.Debugf("chose %s", sessionType)
 	// Create new session
 	awsConfig := &aws.Config{
 		Region:      aws.String(region),

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -2002,9 +2002,12 @@ func createAWSSessionByContext(region string, context *plugin.ActionContext, tim
 	return createAWSSessionByCredentials(region, awsCredentials, timeout)
 }
 
+// access keys have to be both set
+// role arn can be supplied alone if it's irsa
+// role arn and external id have to be supplied together for traditional assume role
 func detectConnectionType(awsCredentials map[string]string) (credsType, key, value string) {
 	if awsCredentials[awsAccessKeyId] == "" || awsCredentials[awsSecretAccessKey] == "" {
-		if awsCredentials[roleArn] == "" || awsCredentials[externalID] == "" {
+		if awsCredentials[roleArn] == "" {
 			return "", "", ""
 		} else {
 			return "roleBased", awsCredentials[roleArn], awsCredentials[externalID]

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -2006,7 +2006,6 @@ func createAWSSessionByContext(region string, context *plugin.ActionContext, tim
 // role arn can be supplied alone if it's irsa
 // role arn and external id have to be supplied together for traditional assume role
 func detectConnectionType(awsCredentials map[string]string) (credsType, key, value string) {
-	log.Debug(awsCredentials[roleArn], awsCredentials[externalID], awsCredentials[awsAccessKeyId], awsCredentials[awsSecretAccessKey])
 	if awsCredentials[awsAccessKeyId] == "" || awsCredentials[awsSecretAccessKey] == "" {
 		if awsCredentials[roleArn] == "" {
 			return "", "", ""

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -2086,7 +2086,7 @@ func assumeRole(role, externalID, region string) (access, secret, sessionToken s
 
 	// irsa does not work with externalID, only the "traditional" assume role does
 	if externalID == "" {
-		return assumeRoleWithWebIdentity(svc, role, sessionToken)
+		return assumeRoleWithWebIdentity(svc, role, sessionName)
 	}
 	return assumeRoleWithTrustedIdentity(svc, role, externalID, sessionName)
 }

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -2031,14 +2031,22 @@ func convertInterfaceMapToStringMap(m map[string]interface{}) map[string]string 
 	return mapString
 }
 
+func readFile(path string) (string, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
 func assumeRoleWithWebIdentity(svc *sts.STS, role, sessionName string) (string, string, string, error) {
 	log.Debug("assuming role with web identity")
 	tokenFile, ok := os.LookupEnv("AWS_WEB_IDENTITY_TOKEN_FILE")
 	if !ok {
-		return "", "", "", fmt.Errorf("token file for irsa not found. make sure your pod is configured correctly and that your service account is created and properly annotated")
+		return "", "", "", fmt.Errorf("token file for irsa not found. make sure your pod is configured correctly and that your service account is created and annotated properly")
 	}
 
-	data, err := ioutil.ReadFile(tokenFile)
+	data, err := readFile(tokenFile)
 	if err != nil {
 		return "", "", "", fmt.Errorf("unable to open web identity token file with error: %w", err)
 	}

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -2052,7 +2052,6 @@ func assumeRole(role, externalID, region string) (access, secret, sessionToken s
 			return access, secret, sessionToken, fmt.Errorf("unable to open web identity token file with error: %w", err)
 		}
 
-		fmt.Println("Contents of file:", string(data))
 		result, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
 			DurationSeconds:  aws.Int64(3600),
 			RoleArn:          aws.String(role),

--- a/implementation/implementation_test.go
+++ b/implementation/implementation_test.go
@@ -73,6 +73,8 @@ func TestAssumeRole(t *testing.T) {
 			wantErr:        "invalid role ARN",
 		},
 	}
+
+	// this part mimics the service account annotation on plugin pods
 	file := "/tmp/lewl123"
 	err := os.WriteFile(file, []byte(""), 0644)
 	defer os.Remove(file)
@@ -81,6 +83,7 @@ func TestAssumeRole(t *testing.T) {
 	}
 	os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", file)
 
+	// mocking the sts client
 	client := &STSMockClient{}
 	for _, tt := range tests {
 		t.Run("test assumeRole(): "+tt.name, func(t *testing.T) {

--- a/implementation/implementation_test.go
+++ b/implementation/implementation_test.go
@@ -1,0 +1,129 @@
+package implementation
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+type STSMockClient struct {
+	stsiface.STSAPI
+}
+
+func (s *STSMockClient) AssumeRole(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+	if *input.ExternalId == "eligezer" {
+		return &sts.AssumeRoleOutput{}, fmt.Errorf("invalid external ID")
+	}
+	return &sts.AssumeRoleOutput{
+		Credentials: &sts.Credentials{
+			AccessKeyId: aws.String("ASDASKDSDASDAS"),
+			SecretAccessKey: aws.String("SADASDQWDDASAS"),
+			SessionToken: aws.String("ASJDHASKJDAS"),
+			},
+	}, nil
+}
+
+func (s *STSMockClient) AssumeRoleWithWebIdentity(input *sts.AssumeRoleWithWebIdentityInput) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	if *input.RoleArn == "arn:aws:iam::12345678910:role/eligezer" {
+		return &sts.AssumeRoleWithWebIdentityOutput{}, fmt.Errorf("invalid role ARN")
+	}
+	return &sts.AssumeRoleWithWebIdentityOutput{
+		Credentials: &sts.Credentials{
+			AccessKeyId: aws.String("ASDASKDSDASDAS"),
+			SecretAccessKey: aws.String("SADASDQWDDASAS"),
+			SessionToken: aws.String("ASJDHASKJDAS"),
+		},
+	}, nil
+}
+
+
+func TestAssumeRole(t *testing.T) {
+	type args struct {
+		role string
+		externalID string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		wantErr        string
+	}{
+		{
+			name:           "successful trused identity assume role",
+			args:           args{role: "arn:aws:iam::12345678910:role/good-role", externalID: "waaaa"},
+			wantErr:        "",
+		},
+		{
+			name:           "unsuccessful trused identity assume role",
+			args:           args{role: "arn:aws:iam::630441286508:role/bad-role", externalID: "eligezer"},
+			wantErr:       "invalid external ID",
+		},
+		{
+			name:           "successful web identity assume role",
+			args:           args{role: "arn:aws:iam::630441286508:role/good-role", externalID: ""},
+			wantErr:        "",
+		},
+		{
+			name:           "unsuccessful web identity assume role",
+			args:           args{role: "arn:aws:iam::12345678910:role/eligezer", externalID: ""},
+			wantErr:        "invalid role ARN",
+		},
+	}
+	file := "/tmp/lewl123"
+	err := os.WriteFile(file, []byte(""), 0644)
+	defer os.Remove(file)
+	if err != nil {
+		t.Error("unable to create temporary file")
+	}
+	os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", file)
+
+	client := &STSMockClient{}
+	for _, tt := range tests {
+		t.Run("test assumeRole(): "+tt.name, func(t *testing.T) {
+			_, _, _, err := assumeRole(client, tt.args.role, tt.args.externalID)
+			if tt.wantErr != "" {
+				require.NotNil(t, err, tt.name)
+				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+			} else {
+				require.Nil(t, err, tt.name)
+			}
+		})
+	}
+}
+
+func TestDetectConnectionType(t *testing.T) {
+	type args struct {
+		awsCreds map[string]string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		credsType      string
+	}{
+		{
+			name:           "user based credentials",
+			args:           args{awsCreds: map[string]string{awsAccessKeyId: "ASDHASDSDHADHASD", awsSecretAccessKey: "ASDSADASDASAS", roleArn: "", externalID: ""}},
+			credsType:      "userBased",
+		},
+		{
+			name:           "role based credentials",
+			args:           args{awsCreds: map[string]string{awsAccessKeyId: "", awsSecretAccessKey: "", roleArn: "arn:aws:iam::12345678910:role/test", externalID: "eligezer"}},
+			credsType:      "roleBased",
+		},
+		{
+			name:           "bad credentials",
+			args:           args{awsCreds: map[string]string{awsAccessKeyId: "", awsSecretAccessKey: "", roleArn: "", externalID: ""}},
+			credsType:      "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run("test ActionExist(): "+tt.name, func(t *testing.T) {
+			result, _, _ := detectConnectionType(tt.args.awsCreds)
+			assert.Equal(t, tt.credsType, result)
+		})
+	}
+}


### PR DESCRIPTION
This commit adds support for assuming role both as Trusted Identity (user creates a role and allows our role to assume it), and Web Identity (user creates a role and assumes it from his POD using OIDC. no reference to our account at all).
